### PR TITLE
Switch CLI integration test to real OpenAI API

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "node ./src/index.js"
+    "start": "node ./src/index.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import OpenAI from "openai";
 import chalk from "chalk";
 import { config as dotEnvConfig } from "dotenv";
 import { getFileId, getVectorStoreId } from "./file_manager.js";
@@ -12,52 +11,61 @@ import {
   getLastResponse,
 } from "./thread_manager.js";
 import { runAssistantOnThread, getRunStatus } from "./run_manager.js";
+import { createOpenAIClient } from "./openai_client.js";
 
 dotEnvConfig({ path: ".env" });
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = await createOpenAIClient();
 
-async function main() {
+async function main(openAiInstance) {
   let runStatus;
+  let runCount = 0;
+  const maxRunsEnv = Number.parseInt(process.env.MAX_RUNS ?? "", 10);
+  const maxRuns = Number.isFinite(maxRunsEnv) && maxRunsEnv > 0 ? maxRunsEnv : Infinity;
+  const pollIntervalEnv = Number.parseInt(
+    process.env.POLL_INTERVAL_MS ?? "2000",
+    10
+  );
+  const pollInterval = Number.isFinite(pollIntervalEnv) && pollIntervalEnv > 0 ? pollIntervalEnv : 2000;
 
   try {
     // 1. Отримання ID файлу
-    const fileId = await getFileId(openai, process.env.FILE_NAME);
+    const fileId = await getFileId(openAiInstance, process.env.FILE_NAME);
 
     console.log(`✔️ Id файлу: ${chalk.grey.bold(fileId)}`);
 
     // 2. Отримання ID асистента
     const assistantId = await getAssistantId(
-      openai,
+      openAiInstance,
       process.env.ASSISTANT_NAME
     );
 
     console.log(`✔️ Id асистента: ${chalk.grey.bold(assistantId)}`);
 
     // 3. Завантажуємо файли у асистента. (Отримуємо векторне сховище)
-    const vectorStoreId = await getVectorStoreId(openai, [fileId]);
+    const vectorStoreId = await getVectorStoreId(openAiInstance, [fileId]);
 
     console.log(`✔️ Id векторного сховища: ${chalk.grey.bold(vectorStoreId)}`);
 
-    await updateAssistantWithVectorStore(openai, assistantId, vectorStoreId);
+    await updateAssistantWithVectorStore(openAiInstance, assistantId, vectorStoreId);
 
     // 4. Отримання ID треду
-    const threadId = await getThreadId(openai);
+    const threadId = await getThreadId(openAiInstance);
 
     console.log(`✔️ Id треду: ${chalk.grey.bold(threadId)}`);
 
     // Логіка надсилання повідомлень і отримування відповідей
-    while (true) {
+    while (runCount < maxRuns) {
       const message = await askUserMessage();
 
       // 5. Додавання повідомлення в тред
-      await addMessageToThread(openai, threadId, message);
+      await addMessageToThread(openAiInstance, threadId, message);
 
       //// Якщо ви хочете додати файл до повідомлення, використовуйте цей код
       // await addMessageToThread(openai, threadId, message, fileId);
 
       // 6. Запуск асистента
       const runObject = await runAssistantOnThread(
-        openai,
+        openAiInstance,
         threadId,
         assistantId
       );
@@ -65,17 +73,19 @@ async function main() {
       // 7. Очікування відповіді
       while (true) {
         // перевіряємо статус запуску кожні 2 секунди
-        await new Promise((resolve) => setTimeout(resolve, 2000));
-        runStatus = await getRunStatus(openai, threadId, runObject.id);
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+        runStatus = await getRunStatus(openAiInstance, threadId, runObject.id);
         if (runStatus.status === "completed" || runStatus.status === "failed") {
           break;
         }
       }
 
       // 8. Отримання відповіді
-      const lastMessage = await getLastResponse(openai, threadId);
+      const lastMessage = await getLastResponse(openAiInstance, threadId);
       console.log(`\n💬 Відповідь асистента: \n ${chalk.cyan.bold(lastMessage)}
       `);
+
+      runCount += 1;
     }
   } catch (error) {
     console.error(chalk.red("Помилка: "), error);
@@ -88,6 +98,11 @@ async function main() {
  * @returns {Promise<string>} The user message.
  */
 async function askUserMessage() {
+  if (process.env.TEST_USER_MESSAGE) {
+    const message = process.env.TEST_USER_MESSAGE;
+    delete process.env.TEST_USER_MESSAGE;
+    return message;
+  }
   return new Promise((resolve, reject) => {
     process.stdout.write(
       chalk.green.bold("\n Введіть повідомлення для асистента: ")
@@ -99,4 +114,4 @@ async function askUserMessage() {
   });
 }
 
-main();
+await main(openai);

--- a/src/openai_client.js
+++ b/src/openai_client.js
@@ -1,0 +1,14 @@
+import OpenAI from "openai";
+
+export async function createOpenAIClient() {
+  if (process.env.USE_MOCK_OPENAI === "true") {
+    const module = await import("./testing/mock-openai.js");
+    return new module.MockOpenAI();
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("❌ Не вказано OPENAI_API_KEY у змінних середовища.");
+  }
+
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+}

--- a/src/testing/mock-openai.js
+++ b/src/testing/mock-openai.js
@@ -1,0 +1,190 @@
+import path from "path";
+
+function createId(prefix, store) {
+  const next = store.nextId + 1;
+  store.nextId = next;
+  return `${prefix}_${next}`;
+}
+
+function mapContent(content) {
+  if (Array.isArray(content)) {
+    return content;
+  }
+
+  return [
+    {
+      type: "text",
+      text: { value: content },
+    },
+  ];
+}
+
+export class MockOpenAI {
+  constructor() {
+    this.state = {
+      files: [],
+      vectorStores: [],
+      assistants: [],
+      threads: new Map(),
+      runs: new Map(),
+      nextId: 0,
+    };
+
+    this.files = {
+      list: async () => ({ data: [...this.state.files] }),
+      create: async ({ file }) => {
+        const id = createId("file", this.state);
+        const filename = path.basename(file.path ?? "mock-file.txt");
+        const newFile = {
+          id,
+          filename,
+          created_at: Math.floor(Date.now() / 1000),
+        };
+        this.state.files.push(newFile);
+        return newFile;
+      },
+    };
+
+    this.beta = {
+      vectorStores: {
+        list: async () => ({ data: [...this.state.vectorStores] }),
+        create: async ({ name, file_ids, expires_after }) => {
+          const id = createId("vs", this.state);
+          const vectorStore = {
+            id,
+            name,
+            file_ids,
+            created_at: Math.floor(Date.now() / 1000),
+            expires_after,
+          };
+          this.state.vectorStores.push(vectorStore);
+          return vectorStore;
+        },
+        del: async (vectorStoreId) => {
+          this.state.vectorStores = this.state.vectorStores.filter(
+            (vectorStore) => vectorStore.id !== vectorStoreId
+          );
+        },
+      },
+      assistants: {
+        list: async () => ({ data: [...this.state.assistants] }),
+        create: async ({ name, instructions, model, tools, temperature }) => {
+          const id = createId("asst", this.state);
+          const assistant = {
+            id,
+            name,
+            instructions,
+            model,
+            tools,
+            temperature,
+            created_at: Math.floor(Date.now() / 1000),
+          };
+          this.state.assistants.push(assistant);
+          return assistant;
+        },
+        update: async (assistantId, payload) => {
+          this.state.assistants = this.state.assistants.map((assistant) =>
+            assistant.id === assistantId
+              ? { ...assistant, tool_resources: payload.tool_resources }
+              : assistant
+          );
+        },
+      },
+      threads: {
+        create: async () => {
+          const id = createId("thread", this.state);
+          this.state.threads.set(id, {
+            id,
+            messages: [],
+          });
+          return { id };
+        },
+        messages: {
+          create: async (threadId, messageObject) => {
+            const thread = this._getThread(threadId);
+            thread.messages.push({
+              id: createId("msg", this.state),
+              role: messageObject.role,
+              content: mapContent(messageObject.content),
+              created_at: Math.floor(Date.now() / 1000),
+            });
+          },
+          list: async (threadId) => {
+            const thread = this._getThread(threadId);
+            return {
+              data: thread.messages.map((message) => ({ ...message })),
+            };
+          },
+        },
+        runs: {
+          create: async (threadId, { assistant_id }) => {
+            const runId = createId("run", this.state);
+            this.state.runs.set(runId, {
+              id: runId,
+              threadId,
+              assistantId: assistant_id,
+              polls: 0,
+            });
+            return { id: runId };
+          },
+          retrieve: async (threadId, runId) => {
+            const run = this.state.runs.get(runId);
+            if (!run) {
+              throw new Error(`Run ${runId} not found`);
+            }
+
+            run.polls += 1;
+
+            if (run.polls < 2) {
+              return { status: "in_progress" };
+            }
+
+            const thread = this._getThread(threadId);
+            const hasAssistantMessage = thread.messages.some(
+              (message) => message.role === "assistant"
+            );
+
+            if (!hasAssistantMessage) {
+              const lastUserMessage = [...thread.messages]
+                .reverse()
+                .find((message) => message.role === "user");
+              const userText =
+                lastUserMessage?.content?.[0]?.text?.value ?? "";
+
+              thread.messages.push({
+                id: createId("msg", this.state),
+                role: "assistant",
+                content: [
+                  {
+                    type: "text",
+                    text: {
+                      value: `Mocked assistant response to: ${userText}`,
+                    },
+                  },
+                ],
+                created_at: Math.floor(Date.now() / 1000),
+              });
+            }
+
+            return {
+              status: "completed",
+              usage: {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+              },
+            };
+          },
+        },
+      },
+    };
+  }
+
+  _getThread(threadId) {
+    const thread = this.state.threads.get(threadId);
+    if (!thread) {
+      throw new Error(`Thread ${threadId} not found`);
+    }
+    return thread;
+  }
+}

--- a/tests/run-project.test.js
+++ b/tests/run-project.test.js
@@ -1,0 +1,94 @@
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import path from "path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+const ANSI_REGEX = /\u001b\[[0-9;]*m/g;
+
+test(
+  "CLI запускається та повертає реальну відповідь від OpenAI",
+  { timeout: 120_000 },
+  async () => {
+    assert.ok(
+      process.env.OPENAI_API_KEY,
+      "Тест потребує реального OPENAI_API_KEY у змінних середовища"
+    );
+
+    const env = {
+      ...process.env,
+      NODE_ENV: "test",
+      MAX_RUNS: "1",
+      POLL_INTERVAL_MS: process.env.POLL_INTERVAL_MS ?? "1000",
+      TEST_USER_MESSAGE: process.env.TEST_USER_MESSAGE ?? "Привіт, як справи?",
+      FILE_NAME: process.env.FILE_NAME ?? "schedule_test_1.md",
+      FOLDER_NAME: process.env.FOLDER_NAME ?? "files",
+      ASSISTANT_NAME: process.env.ASSISTANT_NAME ?? "Test Assistant",
+      OPENAI_MODEL: process.env.OPENAI_MODEL ?? "gpt-4o-mini",
+      OPENAI_TEMPERATURE: process.env.OPENAI_TEMPERATURE ?? "0.2",
+      VECTOR_STORE_NAME:
+        process.env.VECTOR_STORE_NAME ?? "test-vector-store-real-api",
+    };
+
+    const child = spawn("node", ["src/index.js"], {
+      cwd: projectRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+
+    child.stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    await new Promise((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        if (code === 0 || code === null) {
+          resolve();
+        } else {
+          reject(new Error(`Process exited with code ${code}`));
+        }
+      });
+    });
+
+    const sanitizedOutput = output.replace(ANSI_REGEX, "");
+
+    assert.match(
+      sanitizedOutput,
+      /✔️ Id файлу:|Файл "/,
+      "Очікуємо, що файл буде знайдено або створено"
+    );
+    assert.ok(
+      sanitizedOutput.includes("💬 Відповідь асистента"),
+      "Лог повинен містити блок із відповіддю"
+    );
+
+    const responseSection = sanitizedOutput
+      .split("💬 Відповідь асистента:")
+      .slice(1)
+      .join("");
+    const assistantMessage = responseSection
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+
+    assert.ok(
+      assistantMessage && assistantMessage.length > 0,
+      "Асистент має повернути текст відповіді"
+    );
+    assert.ok(
+      !assistantMessage?.includes("Mocked assistant response"),
+      "Очікуємо реальну відповідь, а не мок"
+    );
+  }
+);


### PR DESCRIPTION
## Summary
- update the CLI integration test to require a real OpenAI API key and run against the live API
- reuse existing environment variables or provide sensible defaults for required values
- assert that the assistant response is non-empty and does not come from the mock implementation

## Testing
- npm test *(fails locally: OPENAI_API_KEY not provided for live API call)*

------
https://chatgpt.com/codex/tasks/task_e_68d3db0207bc832d911053e4c2481461