### PR TITLE
Refresh assistant instructions when reusing existing assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+# JetBrains IDEs
+.idea/

--- a/src/assistant_manager.js
+++ b/src/assistant_manager.js
@@ -60,6 +60,8 @@ export async function getAssistantId(openAiInstance, assistantName) {
       )
     );
 
+    await _refreshAssistantInstructions(openAiInstance, latestAssistant);
+
     return latestAssistant.id;
   }
 
@@ -69,6 +71,8 @@ export async function getAssistantId(openAiInstance, assistantName) {
       targetAssistants[0].id
     )}`
   );
+  await _refreshAssistantInstructions(openAiInstance, targetAssistants[0]);
+
   return targetAssistants[0].id;
 }
 
@@ -159,4 +163,27 @@ function _getAssistantInstructions() {
   }
   const assistantInstructions = fs.readFileSync(filePath, "utf8");
   return assistantInstructions;
+}
+
+async function _refreshAssistantInstructions(openAiInstance, assistant) {
+  if (!assistant?.id) {
+    return;
+  }
+
+  const newInstructions = _getAssistantInstructions();
+  const existingInstructions = assistant.instructions ?? "";
+
+  if (existingInstructions === newInstructions) {
+    return;
+  }
+
+  try {
+    await openAiInstance.beta.assistants.update(assistant.id, {
+      instructions: newInstructions,
+    });
+  } catch (error) {
+    throw new Error(
+      chalk.red("❌ Не вдалося оновити інструкції асистента: ") + error.message
+    );
+  }
 }

--- a/tests/assistant_manager.test.js
+++ b/tests/assistant_manager.test.js
@@ -11,7 +11,7 @@ function createTempInstructionsDir(content) {
   return tempDir;
 }
 
-test("оновлює інструкції для існуючого асистента", async () => {
+test("оновлює системні інструкції для існуючого асистента", async () => {
   const originalFolderName = process.env.FOLDER_NAME;
   const tempDir = createTempInstructionsDir("Нові інструкції");
   process.env.FOLDER_NAME = tempDir;

--- a/tests/assistant_manager.test.js
+++ b/tests/assistant_manager.test.js
@@ -1,0 +1,131 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getAssistantId } from "../src/assistant_manager.js";
+
+function createTempInstructionsDir(content) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "assistant-test-"));
+  fs.writeFileSync(path.join(tempDir, "assistant_instructions.md"), content);
+  return tempDir;
+}
+
+test("оновлює інструкції для існуючого асистента", async () => {
+  const originalFolderName = process.env.FOLDER_NAME;
+  const tempDir = createTempInstructionsDir("Нові інструкції");
+  process.env.FOLDER_NAME = tempDir;
+
+  let updateCallCount = 0;
+  let receivedPayload = null;
+
+  const assistant = {
+    id: "asst_123",
+    name: "Test Assistant",
+    created_at: new Date().toISOString(),
+    instructions: "Старі інструкції",
+  };
+
+  const openAiMock = {
+    beta: {
+      assistants: {
+        async list() {
+          return { data: [assistant] };
+        },
+        async update(id, payload) {
+          updateCallCount += 1;
+          receivedPayload = { id, payload };
+        },
+      },
+    },
+  };
+
+  try {
+    const assistantId = await getAssistantId(openAiMock, assistant.name);
+
+    assert.equal(assistantId, assistant.id);
+    assert.equal(updateCallCount, 1);
+    assert.deepEqual(receivedPayload, {
+      id: assistant.id,
+      payload: { instructions: "Нові інструкції" },
+    });
+  } finally {
+    process.env.FOLDER_NAME = originalFolderName;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("не викликає оновлення коли інструкції не змінені", async () => {
+  const originalFolderName = process.env.FOLDER_NAME;
+  const instructions = "Однакові інструкції";
+  const tempDir = createTempInstructionsDir(instructions);
+  process.env.FOLDER_NAME = tempDir;
+
+  let updateCallCount = 0;
+
+  const assistant = {
+    id: "asst_456",
+    name: "Test Assistant",
+    created_at: new Date().toISOString(),
+    instructions,
+  };
+
+  const openAiMock = {
+    beta: {
+      assistants: {
+        async list() {
+          return { data: [assistant] };
+        },
+        async update() {
+          updateCallCount += 1;
+        },
+      },
+    },
+  };
+
+  try {
+    const assistantId = await getAssistantId(openAiMock, assistant.name);
+
+    assert.equal(assistantId, assistant.id);
+    assert.equal(updateCallCount, 0);
+  } finally {
+    process.env.FOLDER_NAME = originalFolderName;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("кидає помилку якщо не вдалося оновити інструкції", async () => {
+  const originalFolderName = process.env.FOLDER_NAME;
+  const tempDir = createTempInstructionsDir("Нові інструкції 2");
+  process.env.FOLDER_NAME = tempDir;
+
+  const assistant = {
+    id: "asst_789",
+    name: "Test Assistant",
+    created_at: new Date().toISOString(),
+    instructions: "Старі інструкції",
+  };
+
+  const openAiMock = {
+    beta: {
+      assistants: {
+        async list() {
+          return { data: [assistant] };
+        },
+        async update() {
+          throw new Error("update failed");
+        },
+      },
+    },
+  };
+
+  try {
+    await assert.rejects(
+      () => getAssistantId(openAiMock, assistant.name),
+      /Не вдалося оновити інструкції/
+    );
+  } finally {
+    process.env.FOLDER_NAME = originalFolderName;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/run-project.test.js
+++ b/tests/run-project.test.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from "url";
 import path from "path";
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { config as dotEnvConfig } from "dotenv";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,13 +11,19 @@ const projectRoot = path.resolve(__dirname, "..");
 
 const ANSI_REGEX = /\u001b\[[0-9;]*m/g;
 
+dotEnvConfig({ path: ".env" });
+
 test(
   "CLI запускається та повертає реальну відповідь від OpenAI",
   { timeout: 120_000 },
   async () => {
+
+      console.log('process.env', process.env);
+
+
     assert.ok(
       process.env.OPENAI_API_KEY,
-      "Тест потребує реального OPENAI_API_KEY у змінних середовища"
+      "Не знайдено OPENAI_API_KEY у змінних оточення"
     );
 
     const env = {


### PR DESCRIPTION
## Summary
- reload instructions from disk when reusing an existing assistant and push updates to OpenAI only when they changed
- add targeted error handling if updating instructions fails
- cover the new behaviour with unit tests that simulate instruction changes

## Testing
- node --test tests/assistant_manager.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de0d7e2998832d9a71eee8c2b54de4